### PR TITLE
LSMACRO-27: Macro does not work with reference parameters that contain spaces 

### DIFF
--- a/src/main/resources/LocationSearch/Code/LocationSearchMacro.xml
+++ b/src/main/resources/LocationSearch/Code/LocationSearchMacro.xml
@@ -915,7 +915,7 @@ form.searchLocation .input-group-btn&gt;input[type="text"]:not(.fixed-width) {
       <code>{{velocity}}
       #set ($title = "")
       #set ($references = $wikimacro.parameters.reference)
-      #if ($references &amp;&amp; $!reference.isEmpty())
+      #if ($references &amp;&amp; $!references.isEmpty())
         #set ($searchLocationDocumentReference = $services.model.resolveDocument($references.get(0)))
         #if ($references.size() == 1)
           #set ($title = $xwiki.getDocument($searchLocationDocumentReference).displayTitle)
@@ -973,7 +973,7 @@ form.searchLocation .input-group-btn&gt;input[type="text"]:not(.fixed-width) {
         (((
           {{html clean=false}}
             &lt;form class='searchLocation form-inline' action='${xwiki.getURL("$wiki:Main.Search")}' role='search'&gt;
-              #if ($references &amp;&amp; $!references.isEmpty())
+              #if ($references &amp;&amp; !$references.isEmpty())
                 #foreach ($reference in $references)
                   #set ($spaceReference = $NULL)
                   #if ($reference != "WebHome" &amp;&amp; !$reference.endsWith(".WebHome"))

--- a/src/main/resources/LocationSearch/Code/LocationSearchMacro.xml
+++ b/src/main/resources/LocationSearch/Code/LocationSearchMacro.xml
@@ -973,7 +973,7 @@ form.searchLocation .input-group-btn&gt;input[type="text"]:not(.fixed-width) {
         (((
           {{html clean=false}}
             &lt;form class='searchLocation form-inline' action='${xwiki.getURL("$wiki:Main.Search")}' role='search'&gt;
-              #if ($references &amp;&amp; !$references.isEmpty())
+              #if ($references &amp;&amp; $!references.isEmpty())
                 #foreach ($reference in $references)
                   #set ($spaceReference = $NULL)
                   #if ($reference != "WebHome" &amp;&amp; !$reference.endsWith(".WebHome"))


### PR DESCRIPTION
### Jira 

[LSMACRO-27](https://jira.xwiki.org/browse/LSMACRO-27)

### Before fix

<img width="1769" height="507" alt="image" src="https://github.com/user-attachments/assets/a699bbf7-f7dc-4c29-8984-e0622f2b5f90" />


### After fix

<img width="1743" height="458" alt="image" src="https://github.com/user-attachments/assets/03702d57-1353-49dc-941e-df200179e95a" />

### Executed tests

None, only manual test the fix
